### PR TITLE
Update newsletter fixture with new vendor ids

### DIFF
--- a/basket/news/fixtures/newsletters.json
+++ b/basket/news/fixtures/newsletters.json
@@ -14,7 +14,7 @@
       "show": true,
       "slug": "mozilla-and-you",
       "title": "Firefox News",
-      "vendor_id": "MOZILLA_AND_YOU"
+      "vendor_id": "96f6577e-6efd-4744-9d96-dbe67b1f48c5"
     },
     "model": "news.newsletter",
     "pk": 1
@@ -34,7 +34,7 @@
       "show": true,
       "slug": "mozilla-foundation",
       "title": "Mozilla News",
-      "vendor_id": "MOZILLA_FOUNDATION"
+      "vendor_id": "c7349bcb-0aae-43d6-a8ef-fc8d5cf68a99"
     },
     "model": "news.newsletter",
     "pk": 2
@@ -54,7 +54,7 @@
       "show": true,
       "slug": "mozilla-festival",
       "title": "Mozilla Festival",
-      "vendor_id": "MOZILLA_FESTIVAL"
+      "vendor_id": "8f2edd8d-042e-4872-85d2-f1e40ee31560"
     },
     "model": "news.newsletter",
     "pk": 3
@@ -74,7 +74,7 @@
       "show": true,
       "slug": "internet-health-report",
       "title": "Internet Health Report",
-      "vendor_id": "INTERNET_HEALTH_REPORT"
+      "vendor_id": "fdac4d45-0d59-4baa-80b2-02f2183934ac"
     },
     "model": "news.newsletter",
     "pk": 4
@@ -94,7 +94,7 @@
       "show": true,
       "slug": "common-voice",
       "title": "Common Voice",
-      "vendor_id": "COMMON_VOICE"
+      "vendor_id": "1336ac70-2176-482c-8ff3-0ea4146d1ebe"
     },
     "model": "news.newsletter",
     "pk": 5
@@ -114,7 +114,7 @@
       "show": false,
       "slug": "guardian-vpn-waitlist",
       "title": "Mozilla VPN Waitlist",
-      "vendor_id": "GUARDIAN_VPN_WAITLIST"
+      "vendor_id": "2a87f6bc-0028-4f2f-8d91-af253ad3cf14"
     },
     "model": "news.newsletter",
     "pk": 9


### PR DESCRIPTION
### Description
Replaces the old fixture vendor_ids with subscription_group_ids from Braze (Mozilla dev)

### Testing
- [ ] basket > devenv up
- [ ] Inspect the newsletter table. All the rows there should now have their corresponding braze id in the vendor_id column