### PR TITLE
POST news/user in Braze

### DIFF
--- a/basket/news/backends/braze.py
+++ b/basket/news/backends/braze.py
@@ -218,5 +218,21 @@ class BrazeClient:
 
         return self._request(BrazeEndpoint.CAMPAIGNS_TRIGGER_SEND, data)
 
+    def update_user_attributes(self, email, attributes):
+        """
+        Track a user in Braze.
+        https://www.braze.com/docs/api/endpoints/user_data/post_user_track/
+
+        """
+        data = {
+            "attributes": [
+                {
+                    "email": email,
+                    "_update_existing_only": True,
+                }
+                | attributes
+            ],
+        }
+        return self._request(BrazeEndpoint.USERS_TRACK, data)
 
 braze = BrazeClient(settings.BRAZE_BASE_API_URL, settings.BRAZE_API_KEY)

--- a/basket/news/backends/braze.py
+++ b/basket/news/backends/braze.py
@@ -220,7 +220,7 @@ class BrazeClient:
 
     def update_user_attributes(self, email, attributes):
         """
-        Track a user in Braze.
+        Updates attributes for an existing user in Braze.
         https://www.braze.com/docs/api/endpoints/user_data/post_user_track/
 
         """
@@ -234,5 +234,6 @@ class BrazeClient:
             ],
         }
         return self._request(BrazeEndpoint.USERS_TRACK, data)
+
 
 braze = BrazeClient(settings.BRAZE_BASE_API_URL, settings.BRAZE_API_KEY)

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -205,7 +205,6 @@ def upsert_user(api_call_type, data):
     )
 
 
-# here
 def upsert_contact(api_call_type, data, user_data):
     """
     Update or insert (upsert) a contact record
@@ -306,9 +305,9 @@ def upsert_contact(api_call_type, data, user_data):
 
     if settings.BRAZE_POST_USER_ENABLE and api_call_type == SET:
         if settings.MAINTENANCE_MODE:
-            braze_update_user_details.delay(update_data, forced_optin)
+            braze_update_user_attributes.delay(update_data, forced_optin)
         else:
-            braze_update_user_details(update_data, forced_optin)
+            braze_update_user_attributes(update_data, forced_optin)
 
     # update record
     if user_data and user_data.get("token"):
@@ -491,9 +490,9 @@ def get_fxa_user_data(fxa_id, email):
 
 
 @rq_task
-def braze_update_user_details(update_data, forced_optin):
+def braze_update_user_attributes(update_data, forced_optin):
     """
-    Updates user details in Braze for existing users
+    Updates user attributes in Braze for existing users
     """
     new_attributes = {}
 

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -257,7 +257,6 @@ def upsert_contact(api_call_type, data, user_data):
         to_subscribe_slugs = [nl for nl, sub in update_data["newsletters"].items() if sub]
         check_optin = not (forced_optin or (user_data and user_data.get("optin")))
         check_mofo = not (user_data and user_data.get("mofo_relevant"))
-        # to_subscribe_braze_ids = list(Newsletter.objects.filter(slug__in=to_subscribe_slugs).values_list("vendor_id", flat=True))
 
         if to_subscribe_slugs and (check_optin or check_mofo):
             to_subscribe = Newsletter.objects.filter(slug__in=to_subscribe_slugs)

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -508,7 +508,7 @@ def braze_update_user_attributes(update_data, forced_optin):
         new_attributes["subscription_groups"] = [
             {
                 "subscription_group_id": newsletter["vendor_id"],
-                "subscription_state": "subscribed" if newsletter["slug"] in update_data["newsletters"] else "unsubscribed",
+                "subscription_state": "subscribed" if update_data["newsletters"].get(newsletter["slug"], False) else "unsubscribed",
             }
             for newsletter in newsletters
         ]

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -503,7 +503,9 @@ def braze_update_user_attributes(update_data, forced_optin):
     new_attributes = {}
 
     if forced_optin == "Y":
-        new_attributes["email_subscribe"] = True
+        new_attributes["email_subscribe"] = "opted_in"
+    if forced_optin == "N":
+        new_attributes["email_subscribe"] = "unsubscribed"
     if update_data.get("country"):
         new_attributes["country"] = update_data["country"]
     if update_data.get("lang"):

--- a/basket/news/tests/test_braze.py
+++ b/basket/news/tests/test_braze.py
@@ -179,6 +179,26 @@ def test_braze_delete_users(braze_client):
         assert m.last_request.json() == expected
 
 
+def test_update_user_attributes(braze_client):
+    email = "test@test.com"
+    attributes = {
+        "country": "CA",
+    }
+    expected = {
+        "attributes": [
+            {
+                "country": "CA",
+                "email": "test@test.com",
+                "_update_existing_only": True,
+            }
+        ]
+    }
+    with requests_mock.mock() as m:
+        m.register_uri("POST", "http://test.com/users/track", json={})
+        braze_client.update_user_attributes(email, attributes)
+        assert m.last_request.json() == expected
+
+
 def test_braze_exception_400(braze_client):
     with requests_mock.mock() as m:
         m.register_uri("POST", "http://test.com/users/track", status_code=400, json={})

--- a/basket/settings.py
+++ b/basket/settings.py
@@ -480,3 +480,5 @@ if OIDC_ENABLE:
         "/readiness/",
         "/watchman/",
     ]
+
+BRAZE_POST_USER_ENABLE = config("BRAZE_POST_USER_ENABLE", parser=bool, default="false")


### PR DESCRIPTION
### Testing
 
- [ ] Set BRAZE_POST_USER_ENABLE=True in your env file
- [ ] `devenv up` on basket and ctms api
- [ ] Grab a basket_token and a corresponding email address from your db (make sure it's of an account you can check in the dev Braze dashboard).
- [ ] Look up that account in Braze dev. Make sure the subscriptions that are listed there match the subscriptions listed for that email address in your ctms db.
- [ ] Using postman, test that endpoint `localhost:9020/news/user/[token_here]` with the body params present in the [API docs - POST news/user](https://basket.readthedocs.io/newsletter_api.html#news-user). The email field is necessary (for now, as we still haven't implemented the Braze reads), everything else can be added optionally (note: format will be ignored, as that's how it's currently setup in the codebase). WARNING: The newsletters key should replace all your subscriptions with whatever you passed in, HOWEVER, the parseNewsletter function will allow you to subscribe to inactive newsletters but not unsubscribe from them using this API call. So if you get weird results involving inactive newsletters, that's why. (I'm not sure if that behaviour is a bug or intentional, but since we're supposed to keep current functionality as is, I kept that as is.)
- [ ] Go to Braze, you should see your changes reflected there.
- [ ] Make sure all tests pass (run `just test` in basket/basket)
