### PR TITLE
Implement Admin DSAR Unsubscribe and DSAR Get Info, update tests

### DIFF
--- a/basket/admin.py
+++ b/basket/admin.py
@@ -104,7 +104,7 @@ class BasketAdminSite(admin.AdminSite):
     def dsar_info_view(self, request):
         form = EmailForm()
         context = {
-            "title": "DSAR: Fetch CTMS User Info by Email Address",
+            "title": "DSAR: Fetch User Info by Email Address",
         }
         if request.method == "POST":
             form = EmailForm(request.POST)
@@ -192,7 +192,7 @@ class BasketAdminSite(admin.AdminSite):
                 form = EmailListForm()
 
         context = {
-            "title": "DSAR: Unsubscribe CTMS Users by Email Address",
+            "title": "DSAR: Unsubscribe Users by Email Address",
             "dsar_form": form,
             "dsar_output": output,
         }
@@ -254,7 +254,7 @@ class BasketAdminSite(admin.AdminSite):
                 form = EmailListForm()
 
         context = {
-            "title": "DSAR: Delete CTMS Data by Email Address",
+            "title": "DSAR: Delete Data by Email Address",
             "dsar_form": form,
             "dsar_output": output,
         }

--- a/basket/base/templates/admin/dsar-info.html
+++ b/basket/base/templates/admin/dsar-info.html
@@ -69,7 +69,7 @@
 
     <div class="output-container">
       {% if dsar_contact %}
-        <h2>User Info:</h2>
+        <h2>User Info (from {{ vendor }}):</h2>
         <table>
             <tr>
                 <th>Primary Email</th>

--- a/basket/base/templates/admin/dsar-info.html
+++ b/basket/base/templates/admin/dsar-info.html
@@ -73,49 +73,49 @@
         <table>
             <tr>
                 <th>Primary Email</th>
-                <td>{{ dsar_contact.email.primary_email }}</td>
+                <td>{{ dsar_contact.email }}</td>
             </tr>
             <tr>
                 <th>Basket Token</th>
-                <td><a href="{{ settings.FXA_EMAIL_PREFS_URL }}/{{ dsar_contact.email.basket_token }}/" target="_blank" title="Open the user's Email Preferences">{{ dsar_contact.email.basket_token }}</a></td>
+                <td><a href="{{ settings.FXA_EMAIL_PREFS_URL }}/{{ dsar_contact.token }}/" target="_blank" title="Open the user's Email Preferences">{{ dsar_contact.token }}</a></td>
             </tr>
-            {% if dsar_contact.email.first_name %}
+            {% if dsar_contact.first_name or dsar_contact.last_name %}
             <tr>
                 <th>Name</th>
-                <td>{{ dsar_contact.email.first_name }} {{ dsar_contact.email.last_name }}</td>
+                <td>{% if dsar_contact.first_name %}{{ dsar_contact.first_name }}{% endif %}{% if dsar_contact.last_name %} {{ dsar_contact.last_name }}{% endif %}</td>
             </tr>
             {% endif %}
             <tr>
                 <th>Language</th>
-                <td>{{ dsar_contact.email.email_lang }}</td>
+                <td>{{ dsar_contact.lang }}</td>
             </tr>
-            {% if dsar_contact.email.mailing_country %}
+            {% if dsar_contact.country %}
             <tr>
                 <th>Country</th>
-                <td>{{ dsar_contact.email.mailing_country }}</td>
+                <td>{{ dsar_contact.country }}</td>
             </tr>
             {% endif %}
             <tr>
                 <th>FxA ID</th>
-                <td>{{ dsar_contact.fxa.fxa_id }}</td>
+                <td>{{ dsar_contact.fxa_id }}</td>
             </tr>
-            {% if dsar_contact.fxa.primary_email %}
+            {% if dsar_contact.fxa_primary_email %}
             <tr>
                 <th>FxA Primary Email</th>
-                <td>{{ dsar_contact.fxa.primary_email }}</td>
+                <td>{{ dsar_contact.fxa_primary_email }}</td>
             </tr>
             {% endif %}
             <tr>
                 <th>MoFo Relevant?</th>
-                <td>{{ dsar_contact.mofo.mofo_relevant|yesno }}</td>
+                <td>{{ dsar_contact.mofo_relevant|yesno }}</td>
             </tr>
             <tr>
                 <th>Double Opt In?</th>
-                <td>{{ dsar_contact.email.double_opt_in|yesno }}</td>
+                <td>{{ dsar_contact.optin|yesno }}</td>
             </tr>
             <tr>
                 <th>Opt Out of All Email?</th>
-                <td>{{ dsar_contact.email.has_opted_out_of_email|yesno }}</td>
+                <td>{{ dsar_contact.optout|yesno }}</td>
             </tr>
             <tr>
                 <th>Subscriptions</th>
@@ -141,7 +141,7 @@
         <pre id="text-content" class="output-text">{{ dsar_contact_pretty }}</pre>
       {% elif dsar_submitted %}
         <h2>Not Found:</h2>
-        <pre id="text-content" class="output-text">User not found in CTMS</pre>
+        <pre id="text-content" class="output-text">User not found in {{ vendor }}</pre>
       {% endif %}
     </div>
   </div>

--- a/basket/base/tests/test_view_admin_dsar.py
+++ b/basket/base/tests/test_view_admin_dsar.py
@@ -5,6 +5,7 @@ from unittest.mock import call, patch
 from django.conf import settings
 from django.contrib.auth.models import Permission, User
 from django.test import Client
+from django.test.utils import override_settings
 from django.urls import reverse
 
 import pytest
@@ -59,6 +60,7 @@ class TestAdminDSARDeleteView(DSARViewTestBase):
         assert isinstance(response.context["dsar_form"], EmailListForm)
         assert response.context["dsar_output"] is None
 
+    @override_settings(BRAZE_ONLY_WRITE_ENABLE=False)
     def test_post_valid_emails(self):
         self._create_admin_user()
         self._login_admin_user()
@@ -76,6 +78,7 @@ class TestAdminDSARDeleteView(DSARViewTestBase):
         assert "DELETED test2@example.com from CTMS (ctms id: 456). fxa: YES." in response.context["dsar_output"]
         assert "DELETED test3@example.com from CTMS (ctms id: 789). fxa: YES. mofo: YES." in response.context["dsar_output"]
 
+    @override_settings(BRAZE_ONLY_WRITE_ENABLE=False)
     def test_post_valid_email(self):
         self._create_admin_user()
         self._login_admin_user()
@@ -87,6 +90,7 @@ class TestAdminDSARDeleteView(DSARViewTestBase):
         assert mock_ctms.delete.called
         assert "DELETED test@example.com from CTMS (ctms id: 123)." in response.context["dsar_output"]
 
+    @override_settings(BRAZE_ONLY_WRITE_ENABLE=False)
     def test_post_unknown_ctms_user(self, mocker):
         self._create_admin_user()
         self._login_admin_user()
@@ -198,6 +202,7 @@ class TestAdminDSARUnsubView(DSARViewTestBase):
         assert isinstance(response.context["dsar_form"], EmailListForm)
         assert response.context["dsar_output"] is None
 
+    @override_settings(BRAZE_ONLY_WRITE_ENABLE=False)
     def test_post_valid_emails(self):
         self._create_admin_user()
         self._login_admin_user()
@@ -222,6 +227,7 @@ class TestAdminDSARUnsubView(DSARViewTestBase):
         assert "UNSUBSCRIBED test2@example.com (ctms id: 456)." in response.context["dsar_output"]
         assert "UNSUBSCRIBED test3@example.com (ctms id: 789)." in response.context["dsar_output"]
 
+    @override_settings(BRAZE_ONLY_WRITE_ENABLE=False)
     def test_post_valid_email(self):
         self._create_admin_user()
         self._login_admin_user()
@@ -234,6 +240,7 @@ class TestAdminDSARUnsubView(DSARViewTestBase):
         mock_ctms.interface.patch_by_email_id.assert_called_with("123", self.update_data)
         assert "UNSUBSCRIBED test@example.com (ctms id: 123)." in response.context["dsar_output"]
 
+    @override_settings(BRAZE_ONLY_WRITE_ENABLE=False)
     def test_post_unknown_ctms_user(self, mocker):
         self._create_admin_user()
         self._login_admin_user()

--- a/basket/base/tests/test_view_admin_dsar.py
+++ b/basket/base/tests/test_view_admin_dsar.py
@@ -5,7 +5,6 @@ from unittest.mock import call, patch
 from django.conf import settings
 from django.contrib.auth.models import Permission, User
 from django.test import Client
-from django.test.utils import override_settings
 from django.urls import reverse
 
 import pytest
@@ -60,8 +59,6 @@ class TestAdminDSARDeleteView(DSARViewTestBase):
         assert isinstance(response.context["dsar_form"], EmailListForm)
         assert response.context["dsar_output"] is None
 
-    @override_settings(BRAZE_PARALLEL_WRITE_ENABLE=False)
-    @override_settings(BRAZE_ONLY_WRITE_ENABLE=False)
     def test_post_valid_emails(self):
         self._create_admin_user()
         self._login_admin_user()
@@ -79,8 +76,6 @@ class TestAdminDSARDeleteView(DSARViewTestBase):
         assert "DELETED test2@example.com from CTMS (ctms id: 456). fxa: YES." in response.context["dsar_output"]
         assert "DELETED test3@example.com from CTMS (ctms id: 789). fxa: YES. mofo: YES." in response.context["dsar_output"]
 
-    @override_settings(BRAZE_PARALLEL_WRITE_ENABLE=False)
-    @override_settings(BRAZE_ONLY_WRITE_ENABLE=False)
     def test_post_valid_email(self):
         self._create_admin_user()
         self._login_admin_user()
@@ -92,8 +87,6 @@ class TestAdminDSARDeleteView(DSARViewTestBase):
         assert mock_ctms.delete.called
         assert "DELETED test@example.com from CTMS (ctms id: 123)." in response.context["dsar_output"]
 
-    @override_settings(BRAZE_PARALLEL_WRITE_ENABLE=False)
-    @override_settings(BRAZE_ONLY_WRITE_ENABLE=False)
     def test_post_unknown_ctms_user(self, mocker):
         self._create_admin_user()
         self._login_admin_user()
@@ -205,8 +198,6 @@ class TestAdminDSARUnsubView(DSARViewTestBase):
         assert isinstance(response.context["dsar_form"], EmailListForm)
         assert response.context["dsar_output"] is None
 
-    @override_settings(BRAZE_PARALLEL_WRITE_ENABLE=False)
-    @override_settings(BRAZE_ONLY_WRITE_ENABLE=False)
     def test_post_valid_emails(self):
         self._create_admin_user()
         self._login_admin_user()
@@ -231,8 +222,6 @@ class TestAdminDSARUnsubView(DSARViewTestBase):
         assert "UNSUBSCRIBED test2@example.com (ctms id: 456)." in response.context["dsar_output"]
         assert "UNSUBSCRIBED test3@example.com (ctms id: 789)." in response.context["dsar_output"]
 
-    @override_settings(BRAZE_PARALLEL_WRITE_ENABLE=False)
-    @override_settings(BRAZE_ONLY_WRITE_ENABLE=False)
     def test_post_valid_email(self):
         self._create_admin_user()
         self._login_admin_user()
@@ -245,8 +234,6 @@ class TestAdminDSARUnsubView(DSARViewTestBase):
         mock_ctms.interface.patch_by_email_id.assert_called_with("123", self.update_data)
         assert "UNSUBSCRIBED test@example.com (ctms id: 123)." in response.context["dsar_output"]
 
-    @override_settings(BRAZE_PARALLEL_WRITE_ENABLE=False)
-    @override_settings(BRAZE_ONLY_WRITE_ENABLE=False)
     def test_post_unknown_ctms_user(self, mocker):
         self._create_admin_user()
         self._login_admin_user()

--- a/basket/base/tests/test_view_admin_dsar.py
+++ b/basket/base/tests/test_view_admin_dsar.py
@@ -197,7 +197,7 @@ class TestAdminDSARInfoView(DSARViewTestBase):
 
         assert response.status_code == 200
         mock_ctms.interface.get_by_alternate_id.assert_called_with(primary_email="test@example.com")
-        assert response.context["dsar_contact"]["email"]["basket_token"] == "0723e863-cff2-4f74-b492-82b861732d19"
+        assert response.context["dsar_contact"]["token"] == "0723e863-cff2-4f74-b492-82b861732d19"
 
     def test_post_valid_email_braze(self):
         self._create_admin_user()
@@ -209,7 +209,7 @@ class TestAdminDSARInfoView(DSARViewTestBase):
 
         assert response.status_code == 200
         mock_ctms.interface.get_by_alternate_id.assert_called_with(primary_email="test@example.com")
-        assert response.context["dsar_contact"]["email"]["basket_token"] == "0723e863-cff2-4f74-b492-82b861732d19"
+        assert response.context["dsar_contact"]["token"] == "0723e863-cff2-4f74-b492-82b861732d19"
 
     def test_post_unknown_ctms_user(self, mocker):
         self._create_admin_user()

--- a/basket/base/tests/test_view_admin_dsar.py
+++ b/basket/base/tests/test_view_admin_dsar.py
@@ -60,6 +60,7 @@ class TestAdminDSARDeleteView(DSARViewTestBase):
         assert isinstance(response.context["dsar_form"], EmailListForm)
         assert response.context["dsar_output"] is None
 
+    @override_settings(BRAZE_PARALLEL_WRITE_ENABLE=False)
     @override_settings(BRAZE_ONLY_WRITE_ENABLE=False)
     def test_post_valid_emails(self):
         self._create_admin_user()
@@ -78,6 +79,7 @@ class TestAdminDSARDeleteView(DSARViewTestBase):
         assert "DELETED test2@example.com from CTMS (ctms id: 456). fxa: YES." in response.context["dsar_output"]
         assert "DELETED test3@example.com from CTMS (ctms id: 789). fxa: YES. mofo: YES." in response.context["dsar_output"]
 
+    @override_settings(BRAZE_PARALLEL_WRITE_ENABLE=False)
     @override_settings(BRAZE_ONLY_WRITE_ENABLE=False)
     def test_post_valid_email(self):
         self._create_admin_user()
@@ -90,6 +92,7 @@ class TestAdminDSARDeleteView(DSARViewTestBase):
         assert mock_ctms.delete.called
         assert "DELETED test@example.com from CTMS (ctms id: 123)." in response.context["dsar_output"]
 
+    @override_settings(BRAZE_PARALLEL_WRITE_ENABLE=False)
     @override_settings(BRAZE_ONLY_WRITE_ENABLE=False)
     def test_post_unknown_ctms_user(self, mocker):
         self._create_admin_user()
@@ -202,6 +205,7 @@ class TestAdminDSARUnsubView(DSARViewTestBase):
         assert isinstance(response.context["dsar_form"], EmailListForm)
         assert response.context["dsar_output"] is None
 
+    @override_settings(BRAZE_PARALLEL_WRITE_ENABLE=False)
     @override_settings(BRAZE_ONLY_WRITE_ENABLE=False)
     def test_post_valid_emails(self):
         self._create_admin_user()
@@ -227,6 +231,7 @@ class TestAdminDSARUnsubView(DSARViewTestBase):
         assert "UNSUBSCRIBED test2@example.com (ctms id: 456)." in response.context["dsar_output"]
         assert "UNSUBSCRIBED test3@example.com (ctms id: 789)." in response.context["dsar_output"]
 
+    @override_settings(BRAZE_PARALLEL_WRITE_ENABLE=False)
     @override_settings(BRAZE_ONLY_WRITE_ENABLE=False)
     def test_post_valid_email(self):
         self._create_admin_user()
@@ -240,6 +245,7 @@ class TestAdminDSARUnsubView(DSARViewTestBase):
         mock_ctms.interface.patch_by_email_id.assert_called_with("123", self.update_data)
         assert "UNSUBSCRIBED test@example.com (ctms id: 123)." in response.context["dsar_output"]
 
+    @override_settings(BRAZE_PARALLEL_WRITE_ENABLE=False)
     @override_settings(BRAZE_ONLY_WRITE_ENABLE=False)
     def test_post_unknown_ctms_user(self, mocker):
         self._create_admin_user()

--- a/basket/news/tests/test_braze.py
+++ b/basket/news/tests/test_braze.py
@@ -673,6 +673,7 @@ def test_braze_get(mock_newsletters, braze_client):
         assert api_requests[1].url == "http://test.com/subscription/user/status?external_id=123&email=test%40example.com"
 
 
+@override_settings(BRAZE_PARALLEL_WRITE_ENABLE=False)
 @override_settings(BRAZE_ONLY_WRITE_ENABLE=False)
 @mock.patch(
     "basket.news.newsletters._newsletters",
@@ -696,6 +697,7 @@ def test_braze_add(mock_newsletters, braze_client):
             assert m.last_request.json() == braze_instance.to_vendor(None, new_user)
 
 
+@override_settings(BRAZE_PARALLEL_WRITE_ENABLE=False)
 @override_settings(BRAZE_ONLY_WRITE_ENABLE=False)
 @mock.patch(
     "basket.news.newsletters._newsletters",


### PR DESCRIPTION
### Testing

- [ ] Set `BRAZE_PARALLEL_WRITE_ENABLE=True` and `BRAZE_READ_WITH_FALLBACK_ENABLE=True` in your env file
- [ ] Start CTMS and Basket
- [ ] Log in as admin

**Testing DSAR Unsubscribe**
- [ ] Grab an email address that exists in dev Braze. Check the dashboard to ensure that the email you selected is either subscribed or opted in and has at least one active newsletter ("Engagement" tab).
- [ ] Use the DSAR Unsubscribe tool with that email address. It should work, and once you refresh Braze, you should see that email set to 'Unsubscribed' in the Engagement tab and no active subscriptions. If that email exists in CTMS, it should also work as expected.

**Testing DSAR Get Info**
- [ ] Look up an email address that exists in dev Braze with the DSAR Get Info tool. You should see the user data from Braze displayed correctly there.
- [ ] Now do the same for an email address that exists in your local CTMS but not in dev Braze. You should see the user data from CTMS displayed correctly there. (The raw data will be formatted differently from the one you saw from Braze, as CTMS exports it differently.)
- [ ] If you look up an address that doesn't exist in either of them, it should tell you it's not found.
- [ ] Set `BRAZE_READ_ONLY_ENABLE=True` and look up the user that only exists in CTMS. It shouldn't find it anymore, as it'll only search Braze at that point.
