### PR TITLE
Fix email_subscribe order

### DIFF
--- a/basket/admin.py
+++ b/basket/admin.py
@@ -181,7 +181,7 @@ class BasketAdminSite(admin.AdminSite):
                             email_id = contact["email_id"]
                             try:
                                 if use_braze_backend:
-                                    braze.update(contact, {"optout": True, "unsub_reason": "User requested global unsubscribe"})
+                                    braze.update(contact, {"optout": True, "unsub_reason": update_data["email"]["unsubscribe_reason"]})
                                 else:
                                     ctms.interface.patch_by_email_id(email_id, update_data)
                             except CTMSNotFoundByEmailIDError:

--- a/basket/admin.py
+++ b/basket/admin.py
@@ -181,7 +181,7 @@ class BasketAdminSite(admin.AdminSite):
                             email_id = contact["email_id"]
                             try:
                                 if use_braze_backend:
-                                    braze.update(contact, {"optout": True})
+                                    braze.update(contact, {"optout": True, "unsub_reason": "User requested global unsubscribe"})
                                 else:
                                     ctms.interface.patch_by_email_id(email_id, update_data)
                             except CTMSNotFoundByEmailIDError:

--- a/basket/base/tests/test_view_admin_dsar.py
+++ b/basket/base/tests/test_view_admin_dsar.py
@@ -365,7 +365,7 @@ class TestAdminDSARUnsubView(DSARViewTestBase):
 
         assert response.status_code == 200
         assert mock_braze.get.call_count == 3
-        mock_braze.update.assert_has_calls([call(user, {"optout": True}) for user in mock_users])
+        mock_braze.update.assert_has_calls([call(user, {"optout": True, "unsub_reason": "User requested global unsubscribe"}) for user in mock_users])
         assert "UNSUBSCRIBED test1@example.com (Braze external id: 123)." in response.context["dsar_output"]
         assert "UNSUBSCRIBED test2@example.com (Braze external id: 456)." in response.context["dsar_output"]
         assert "UNSUBSCRIBED test3@example.com (Braze external id: 789)." in response.context["dsar_output"]
@@ -392,7 +392,9 @@ class TestAdminDSARUnsubView(DSARViewTestBase):
 
         assert response.status_code == 200
         assert mock_braze.get.called
-        mock_braze.update.assert_called_with({"email_id": "123", "fxa_id": "", "mofo_contact_id": ""}, {"optout": True})
+        mock_braze.update.assert_called_with(
+            {"email_id": "123", "fxa_id": "", "mofo_contact_id": ""}, {"optout": True, "unsub_reason": "User requested global unsubscribe"}
+        )
         assert "UNSUBSCRIBED test@example.com (Braze external id: 123)." in response.context["dsar_output"]
 
     def test_post_unknown_ctms_user(self, mocker):

--- a/basket/news/backends/braze.py
+++ b/basket/news/backends/braze.py
@@ -586,7 +586,7 @@ class Braze:
             "email": updated_user_data.get("email"),
             "update_timestamp": now,
             "_update_existing_only": bool(existing_user_data),
-            "email_subscribe": "opted_in" if updated_user_data.get("optin") else "unsubscribed" if updated_user_data.get("optout") else "subscribed",
+            "email_subscribe": "unsubscribed" if updated_user_data.get("optout") else "opted_in" if updated_user_data.get("optin") else "subscribed",
             "subscription_groups": subscription_groups,
             "user_attributes_v1": [
                 {

--- a/basket/news/tasks.py
+++ b/basket/news/tasks.py
@@ -537,7 +537,7 @@ def confirm_user(token, use_braze_backend=False, extra_metrics_tags=None):
         raise BasketError(f"token has no email in {'Braze' if use_braze_backend else 'CTMS'}")
 
     if use_braze_backend:
-        braze.update(user_data, {"optin": True})
+        braze.update(user_data, {"optin": True, "optout": False})
     else:
         ctms.update(user_data, {"optin": True})
 


### PR DESCRIPTION
### Testing

- [ ] Set a test user in dev Braze to 'opted in' in the dashboard.
- [ ] Unsubscribe that user using the Admin DSAR Unsubscribe tool. It should work as expected. The unsub reason should be recorded there.
- [ ] Use postman to subscribe or opt in that user again through either the [news/subscribe](https://basket.readthedocs.io/newsletter_api.html#news-subscribe) or the [news/user](https://basket.readthedocs.io/newsletter_api.html#news-user) endpoint. It should work as expected as well.
- [ ] You should be able to optout the the user through the [news/unsubscribe](https://basket.readthedocs.io/newsletter_api.html#news-unsubscribe) endpoint as well (optout: Y).